### PR TITLE
feat: updated dovecot configuration, by adding DH params, and vmail user

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You will probably save yourself some refactors if do not set variables inline, b
 - install and configure amavis
 - install and configure opendkim
 - install and configure opendmarc
-- install and configure dovecot with system-users being able to login and receive mail
+- install and configure dovecot with system-users and virtual mail directory
 - configure mailutils (installed by role this is dependant on)
 - install and configure opendmarc dashboard (WIP)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A simple way to run this role on a host, is the following:
     postfix_mydomain: "<< Pass the postfix domain here, defaults to myhostname >>"
     postfix_mynetworks:
       - 127.0.0.0/8
-      - "[::1]/128"
+      - "::1/128" # You do not have to bracket IPv6 addresses, this is taken care of by filters
     # Add additional networks when required
     postfix_virtual_alias_domains: [] # Add virtual aliases domains when required (see meta/main.yaml for structure)
     postfix_relay_domains: [] # Add relay domains when required (see defaults/main.yaml for structure)
@@ -85,7 +85,6 @@ You will probably save yourself some refactors if do not set variables inline, b
 - install and configure opendmarc
 - install and configure dovecot with system-users and virtual mail directory
 - configure mailutils (installed by role this is dependant on)
-- install and configure opendmarc dashboard (WIP)
 
 # What this role does not do
 
@@ -108,7 +107,7 @@ This role validates the passed variables. If you:
 
 There are still a number of things which can be improved for this role. The following things are things I am considering of adding:
 
-- Finish implementing opendmarc dashboard
+- Add a dmarc parsing tool
 - Add a better backend to the postfix server, like a database instead of the bare filesystem.
 
 If you have other Improvements, feel free to open an issue.

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,11 +1,19 @@
 ---
-postfix_ipv4: "{{ '' | default(ipv4, true) }}"
-postfix_ipv6: "{{ '' | default(ipv6, true) }}"
-postfix_myhostname: "{{ '' | default(domain, true) }}"
+postfix_ipv4: ""
+postfix_ipv6: ""
+postfix_myhostname: ""
 postfix_mydomain: "{{ '' | default(postfix_myhostname, true) }}"
+
+postfix_mydestination:
+  - $myhostname
+  - localhost.$mydomain
+  - localhost
+  - $mydomain
+  - mail.$mydomain
+
 postfix_mynetworks:
   - 127.0.0.0/8
-  - "[::1]/128"
+  - "::1/128"
 postfix_virtual_alias_domains: []
 postfix_relay_domains: []
 postfix_aliases:

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -38,3 +38,4 @@ postfix_smtpd_tls_key_file: "/etc/letsencrypt/live/{{ postfix_mydomain }}/privke
 
 postfix_dovecot_deny_users:
   - root
+postfix_dovecot_dh_params_size: 4096

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+import ipaddress
+
+from ansible.errors import AnsibleFilterError
+from ansible.template import AnsibleUndefined
+
+
+class FilterModule:
+    """custom filter to check if something is a list"""
+
+    def filters(self):
+        return {
+            "bracket_ipv6": self.bracket_ipv6,
+        }
+
+    def bracket_ipv6(self, obj):
+        """Bracket an IPv6 network, leave IPv4 networks unmodified, e.g:
+        ::1/128     -> [::1]/128
+        127.0.0.1   -> 127.0.0.1"""
+
+        if isinstance(obj, AnsibleUndefined):
+            return []
+
+        elif not isinstance(obj, str):
+            raise AnsibleFilterError("This only works on a IPv4 or IPv6 network string")
+
+        network, address = None, None
+
+        try:
+            network = ipaddress.ip_network(obj)
+        except:
+            pass
+
+        try:
+            address = ipaddress.ip_address(obj)
+        except:
+            pass
+
+        if not network and not address:
+            raise ValueError("Passed value is not an IP-address")
+
+        elif isinstance(address, ipaddress.IPv6Address):
+            return "[" + obj + "]"
+
+        elif isinstance(network, ipaddress.IPv6Network):
+            return "[" + obj.replace("/", "]/")
+
+        else:
+            return obj

--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -163,3 +163,9 @@ argument_specs:
         default:
           - "root"
         description: list of users which are denied logging in in dovecot
+
+      postfix_dovecot_dh_params_size:
+        type: int
+        required: false
+        default: 4096
+        description: the size of the DH params generated for dovecot

--- a/meta/main.yaml
+++ b/meta/main.yaml
@@ -51,12 +51,23 @@ argument_specs:
         required: false
         default: "{{ postfix_myhostname }}"
         description: The hostname of the postfix mail server, defaults to the hostname passed as a variable
+      postfix_mydestination:
+        type: list
+        elements: str
+        required: false
+        default:
+          - $myhostname
+          - localhost.$mydomain
+          - localhost
+          - $mydomain
+          - mail.$mydomain
+        description: The domains postfix sees as it's own destination, the default is pretty sane
       postfix_mynetworks:
         type: list
         elements: str
         default:
           - 127.0.0.0/8
-          - "[::1]/128"
+          - "::1/128"
         required: false
         description: Networks which postfix sees as coming from itself. These are allowed to send emails, origination from the server.
       postfix_relay_domains:

--- a/molecule/default/vars/test.yaml
+++ b/molecule/default/vars/test.yaml
@@ -12,3 +12,6 @@ postfix_aliases:
 postfix_dkim_enabled: false
 postfix_smtpd_tls_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
 postfix_smtpd_tls_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
+
+# Reduced size for testing
+postfix_dovecot_dh_params_size: 1024

--- a/tasks/dovecot.yaml
+++ b/tasks/dovecot.yaml
@@ -1,4 +1,23 @@
 ---
+- name: Edited ownership of /var/mail
+  ansible.builtin.file:
+    path: /var/mail/
+    state: directory
+    owner: vmail
+    group: vmail
+    mode: u=rwx,g=,o=
+  become: true
+
+- name: Generate Diffie-Hellman parameters with size ({{ postfix_dovecot_dh_params_size }} 4096 bits)
+  community.crypto.openssl_dhparam:
+    path: /etc/dovecot/dhparams.pem
+    size: "{{ postfix_dovecot_dh_params_size }}"
+    state: present
+  become: true
+  # I disagree with name[template], as it is sort of at the end here
+  tags:
+    - skip_ansible_lint
+
 - name: Copy dovecot configuration file
   ansible.builtin.template:
     src: dovecot/{{ config }}.j2

--- a/tasks/dovecot.yaml
+++ b/tasks/dovecot.yaml
@@ -5,10 +5,12 @@
     state: directory
     owner: vmail
     group: vmail
-    mode: u=rwx,g=,o=
+    # set uid for group
+    mode: u=rwx-s,g=rwx,o=,g+s,+t
   become: true
+  ignore_errors: "{{ ansible_check_mode }}"
 
-- name: Generate Diffie-Hellman parameters with size ({{ postfix_dovecot_dh_params_size }} 4096 bits)
+- name: Generate Diffie-Hellman parameters with size ({{ postfix_dovecot_dh_params_size }} bits)
   community.crypto.openssl_dhparam:
     path: /etc/dovecot/dhparams.pem
     size: "{{ postfix_dovecot_dh_params_size }}"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -85,6 +85,7 @@
   loop:
     - mail.log
     - mail.err
+    - mail.warn
   loop_control:
     loop_var: log_file
   become: true

--- a/tasks/users.yaml
+++ b/tasks/users.yaml
@@ -1,19 +1,19 @@
 ---
-- name: Adding existing user clamav to amavis group
+- name: Adding existing user "clamav" to "amavis" group
   ansible.builtin.user:
     name: clamav
     groups: amavis
     append: true
   become: true
 
-- name: Adding existing user postfix user to opendkim group
+- name: Adding existing user "postfix" user to opendkim group
   ansible.builtin.user:
     name: postfix
     groups: amavis
     append: true
   become: true
 
-- name: Add opendkim and policyd-spf users
+- name: Add "opendkim" and "policyd-spf" users
   ansible.builtin.user:
     name: "{{ user_name }}"
     state: present
@@ -31,7 +31,7 @@
     state: present
   become: true
 
-- name: Add vmail user for dovecot
+- name: Add "vmail" user for dovecot
   ansible.builtin.user:
     name: vmail
     groups: vmail
@@ -40,7 +40,7 @@
     system: true
   become: true
 
-- name: Add dovecot user
+- name: Add "dovecot" user
   ansible.builtin.user:
     name: dovecot
     system: true

--- a/tasks/users.yaml
+++ b/tasks/users.yaml
@@ -25,9 +25,23 @@
   loop_control:
     loop_var: user_name
 
-- name: Add dovecode user to mail group
+- name: Ensure group "vmail" exists
+  ansible.builtin.group:
+    name: vmail
+    state: present
+  become: true
+
+- name: Add vmail user for dovecot
+  ansible.builtin.user:
+    name: vmail
+    groups: vmail
+    home: /var/mail/
+    create_home: true
+    system: true
+  become: true
+
+- name: Add dovecot user
   ansible.builtin.user:
     name: dovecot
-    groups: mail
-    append: true
+    system: true
   become: true

--- a/templates/dovecot/conf.d/10-mail.conf.j2
+++ b/templates/dovecot/conf.d/10-mail.conf.j2
@@ -46,7 +46,7 @@ namespace inbox {
   # Hierarchy separator to use. You should use the same separator for all
   # namespaces or some clients get confused. '/' is usually a good one.
   # The default however depends on the underlying mail storage format.
-  #separator =
+  separator = /
 
   # Prefix required to access this namespace. This needs to be different for
   # all namespaces. For example "Public/".
@@ -290,7 +290,7 @@ protocol !indexer-worker {
 
 # Assume Dovecot is the only MUA accessing Maildir: Scan cur/ directory only
 # when its mtime changes unexpectedly or when we can't find the mail otherwise.
-#maildir_very_dirty_syncs = no
+maildir_very_dirty_syncs = yes
 
 # If enabled, Dovecot doesn't use the S=<size> in the Maildir filenames for
 # getting the mail's physical size, except when recalculating Maildir++ quota.
@@ -349,7 +349,9 @@ protocol !indexer-worker {
 
 # Like mbox_dirty_syncs, but don't do full syncs even with SELECT, EXAMINE,
 # EXPUNGE or CHECK commands. If this is set, mbox_dirty_syncs is ignored.
-#mbox_very_dirty_syncs = no
+
+# For better performance
+mbox_very_dirty_syncs = yes
 
 # Delay writing mbox headers until doing a full write sync (EXPUNGE and CHECK
 # commands and when closing the mailbox). This is especially useful for POP3

--- a/templates/dovecot/conf.d/10-mail.conf.j2
+++ b/templates/dovecot/conf.d/10-mail.conf.j2
@@ -27,7 +27,7 @@
 #
 # <doc/wiki/MailLocation.txt>
 #
-mail_location = maildir:~/Maildir
+mail_location = sdbox:/var/mail/%n/
 
 # If you need to set multiple mailbox locations or want to change default
 # namespace settings, you can do it by defining namespace sections.
@@ -175,7 +175,7 @@ mail_privileged_group = mail
 # to make sure that users can't log in as daemons or other system users.
 # Note that denying root logins is hardcoded to dovecot binary and can't
 # be done even if first_valid_uid is set to 0.
-#first_valid_uid = 500
+first_valid_uid = 1000
 #last_valid_uid = 0
 
 # Valid GID range for users, defaults to non-root/wheel. Users having

--- a/templates/dovecot/conf.d/10-ssl.conf.j2
+++ b/templates/dovecot/conf.d/10-ssl.conf.j2
@@ -59,7 +59,7 @@ ssl_dh = </etc/dovecot/dhparams.pem
 #
 # Dovecot also recognizes values ANY and LATEST. ANY matches with any protocol
 # version, and LATEST matches with the latest version supported by library.
-ssl_min_protocol = TLSv1.3
+ssl_min_protocol = TLSv1.2
 
 # SSL ciphers to use, the default is:
 #ssl_cipher_list = ALL:!kRSA:!SRP:!kDHd:!DSS:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!RC4:!ADH:!LOW@STRENGTH

--- a/templates/dovecot/conf.d/10-ssl.conf.j2
+++ b/templates/dovecot/conf.d/10-ssl.conf.j2
@@ -52,19 +52,19 @@ ssl_client_ca_dir = /etc/ssl/certs
 # Generate new params with `openssl dhparam -out /etc/dovecot/dh.pem 4096`
 # Or migrate from old ssl-parameters.dat file with the command dovecot
 # gives on startup when ssl_dh is unset.
-ssl_dh = </usr/share/dovecot/dh.pem
+ssl_dh = </etc/dovecot/dhparams.pem
 
 # Minimum SSL protocol version to use. Potentially recognized values are SSLv3,
 # TLSv1, TLSv1.1, TLSv1.2 and TLSv1.3, depending on the OpenSSL version used.
 #
 # Dovecot also recognizes values ANY and LATEST. ANY matches with any protocol
 # version, and LATEST matches with the latest version supported by library.
-#ssl_min_protocol = TLSv1.2
+ssl_min_protocol = TLSv1.3
 
 # SSL ciphers to use, the default is:
 #ssl_cipher_list = ALL:!kRSA:!SRP:!kDHd:!DSS:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!RC4:!ADH:!LOW@STRENGTH
 # To disable non-EC DH, use:
-#ssl_cipher_list = ALL:!DH:!kRSA:!SRP:!kDHd:!DSS:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!RC4:!ADH:!LOW@STRENGTH
+ssl_cipher_list = ALL:!DH:!kRSA:!SRP:!kDHd:!DSS:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!RC4:!ADH:!LOW@STRENGTH
 
 # Colon separated list of elliptic curves to use. Empty value (the default)
 # means use the defaults from the SSL library. P-521:P-384:P-256 would be an

--- a/templates/dovecot/conf.d/auth-system.conf.ext
+++ b/templates/dovecot/conf.d/auth-system.conf.ext
@@ -51,6 +51,7 @@ userdb {
   driver = passwd
   # [blocking=no]
   #args =
+  args = blocking=no
 
   # Override fields from passwd
   override_fields = uid=vmail gid=vmail home=/var/mail/%n/

--- a/templates/dovecot/conf.d/auth-system.conf.ext
+++ b/templates/dovecot/conf.d/auth-system.conf.ext
@@ -1,0 +1,74 @@
+# Authentication for system users. Included from 10-auth.conf.
+#
+# <doc/wiki/PasswordDatabase.txt>
+# <doc/wiki/UserDatabase.txt>
+
+# PAM authentication. Preferred nowadays by most systems.
+# PAM is typically used with either userdb passwd or userdb static.
+# REMEMBER: You'll need /etc/pam.d/dovecot file created for PAM
+# authentication to actually work. <doc/wiki/PasswordDatabase.PAM.txt>
+passdb {
+  driver = pam
+  # [session=yes] [setcred=yes] [failure_show_msg=yes] [max_requests=<n>]
+  # [cache_key=<key>] [<service name>]
+  #args = dovecot
+}
+
+# System users (NSS, /etc/passwd, or similar).
+# In many systems nowadays this uses Name Service Switch, which is
+# configured in /etc/nsswitch.conf. <doc/wiki/AuthDatabase.Passwd.txt>
+#passdb {
+  #driver = passwd
+  # [blocking=no]
+  #args =
+#}
+
+# Shadow passwords for system users (NSS, /etc/shadow or similar).
+# Deprecated by PAM nowadays.
+# <doc/wiki/PasswordDatabase.Shadow.txt>
+#passdb {
+  #driver = shadow
+  # [blocking=no]
+  #args =
+#}
+
+# PAM-like authentication for OpenBSD.
+# <doc/wiki/PasswordDatabase.BSDAuth.txt>
+#passdb {
+  #driver = bsdauth
+  # [blocking=no] [cache_key=<key>]
+  #args =
+#}
+
+##
+## User databases
+##
+
+# System users (NSS, /etc/passwd, or similar). In many systems nowadays this
+# uses Name Service Switch, which is configured in /etc/nsswitch.conf.
+userdb {
+  # <doc/wiki/AuthDatabase.Passwd.txt>
+  driver = passwd
+  # [blocking=no]
+  #args =
+
+  # Override fields from passwd
+  override_fields = uid=vmail gid=vmail home=/var/mail/%n/
+}
+
+# Static settings generated from template <doc/wiki/UserDatabase.Static.txt>
+#userdb {
+  #driver = static
+  # Can return anything a userdb could normally return. For example:
+  #
+  #  args = uid=500 gid=500 home=/var/mail/%u
+  #
+  # LDA and LMTP needs to look up users only from the userdb. This of course
+  # doesn't work with static userdb because there is no list of users.
+  # Normally static userdb handles this by doing a passdb lookup. This works
+  # with most passdbs, with PAM being the most notable exception. If you do
+  # the user verification another way, you can add allow_all_users=yes to
+  # the args in which case the passdb lookup is skipped.
+  #
+  #args =
+#}

--- a/templates/opendkim/opendkim.conf.j2
+++ b/templates/opendkim/opendkim.conf.j2
@@ -60,8 +60,7 @@ ReportAddress "{{ postfix_mydomain }} Postmaster" <postmaster@{{ postfix_mydomai
 # Hosts for which to sign rather than verify, default is 127.0.0.1. See the
 # OPERATION section of opendkim(8) for more information.
 # InternalHosts 192.168.0.0/16, 10.0.0.0/8, 172.16.0.0/12
-InternalHosts 127.0.0.1
-# InternalHosts {{ postfix_dkim_trustedhosts }}
+InternalHosts {{ postfix_dkim_trustedhosts }}
 
 # The trust anchor enables DNSSEC. In Debian, the trust anchor file is provided
 # by the package dns-root-data.

--- a/templates/opendkim/trustedhosts.j2
+++ b/templates/opendkim/trustedhosts.j2
@@ -3,12 +3,10 @@
 ::1
 # Postfix IPs
 {{ postfix_ipv4 }}
-{% if postfix_ipv6 %}{{ postfix_ipv6 }}{% endif %}
+{% if postfix_ipv6 %}{{ postfix_ipv6 }}{% endif +%}
 # DNS names
 localhost
-{% for hostname in postfix_mydestination %}
-{{ hostname }}
-{% endfor %}
+*.{{ postfix_myhostname }}
 # Postfix networks
 {% for network in postfix_mynetworks %}
 {{ network }}

--- a/templates/opendkim/trustedhosts.j2
+++ b/templates/opendkim/trustedhosts.j2
@@ -1,7 +1,15 @@
+# Local IPs
 127.0.0.1
-localhost
 ::1
+# Postfix IPs
 {{ postfix_ipv4 }}
-{% if postfix_ipv6 is sameas true %}{{ postfix_ipv6 }}{% endif %}
-*.{{ postfix_mydomain }}
-
+{% if postfix_ipv6 %}{{ postfix_ipv6 }}{% endif %}
+# DNS names
+localhost
+{% for hostname in postfix_mydestination %}
+{{ hostname }}
+{% endfor %}
+# Postfix networks
+{% for network in postfix_mynetworks %}
+{{ network }}
+{% endfor %}

--- a/templates/postfix/main.cf.j2
+++ b/templates/postfix/main.cf.j2
@@ -133,6 +133,16 @@ myorigin = $mydomain
 append_dot_mydomain = no
 smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
 
+# Enable SMTP Authentication on the Postfix SMTP server using dovecot
+smtpd_sasl_auth_enable = yes
+smtpd_sasl_type = dovecot
+
+# Use local UNIX-domain sockets for communication between Postfix and Dovecot.
+smtpd_sasl_path = private/auth
+
+smtpd_sasl_security_options = noanonymous, noplaintext
+smtpd_sasl_tls_security_options = noanonymous
+
 # RECEIVING MAIL
 
 # The inet_interfaces parameter specifies the network interface
@@ -211,8 +221,7 @@ local_header_rewrite_clients = permit_mynetworks permit_sasl_authenticated permi
 # See also below, section "REJECTING MAIL FOR UNKNOWN LOCAL USERS".
 #
 #mydestination = $myhostname, localhost.$mydomain, localhost
-#mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain
-mydestination = $myhostname, localhost.$mydomain, localhost, $mydomain, mail.$mydomain, www.$mydomain, ftp.$mydomain
+mydestination = {{ postfix_mydestination | join(', ')}}
 
 mynetworks_style = host
 
@@ -277,11 +286,19 @@ local_recipient_maps = proxy:unix:passwd.byname $alias_maps
 # with 450 (try again later) until you are certain that your
 # local_recipient_maps settings are OK.
 #
+
+unknown_address_reject_code  = 554
+unknown_hostname_reject_code = 554
+unknown_client_reject_code   = 554
 unknown_local_recipient_reject_code = 550
 
 # Dovecot required
 # The first line tells Postfix to deliver incoming emails to local message store via the Dovecot LMTP server.
 # The second line disables SMTPUTF8 in Postfix, because Dovecot-LMTP doesn’t support this email extension.
+
+virtual_uid_maps = static:5000
+virtual_gid_maps = static:5000
+
 mailbox_transport = lmtp:unix:private/dovecot-lmtp
 virtual_transport = lmtp:unix:private/dovecot-lmtp
 smtputf8_enable = no
@@ -330,7 +347,7 @@ smtputf8_enable = no
 #mynetworks = 168.100.3.0/28, 127.0.0.0/8
 #mynetworks = $config_directory/mynetworks
 #mynetworks = hash:/etc/postfix/network_table
-mynetworks = {{ postfix_mynetworks | join(', ') }}
+mynetworks = {{ postfix_mynetworks | map("bracket_ipv6") | join(', ') }}
 
 # The relay_domains parameter restricts what destinations this system will
 # relay mail to.  See the smtpd_recipient_restrictions description in
@@ -492,7 +509,7 @@ recipient_delimiter = +
 # UNIX-style mailboxes are kept. The default setting depends on the
 # system type.
 #
-#mail_spool_directory = /var/mail
+mail_spool_directory = /var/mail
 #mail_spool_directory = /var/spool/mail
 
 # The mailbox_command parameter specifies the optional external
@@ -669,13 +686,13 @@ smtpd_tls_eecdh_grade = ultra
 # set up EECDH parameters for 192-bits security level (ignored from Postfix version 3.6)
 # smtpd_tls_dh1024_param_file = /etc/postfix/dh4096.pem
 
-smtpd_tls_loglevel = 1
 smtpd_tls_session_cache_timeout = 3600s
 
 # strong DHE parameters
 smtpd_tls_session_cache_database = btree:/var/lib/postfix/smtpd_tls_session_cache
 tls_random_source = dev:/dev/urandom
 
+# Is not enabled, but is good to set anyway.
 # LMTP from your server to others
 lmtp_tls_note_starttls_offer = yes
 lmtp_tls_protocols =           !SSLv2, !SSLv3, !TLSv1, !TLSv1.1
@@ -805,5 +822,4 @@ debugger_command =
 # sample_directory =
 
 # readme_directory: The location of the Postfix README files.
-#
 readme_directory = no

--- a/templates/postfix/master.cf.j2
+++ b/templates/postfix/master.cf.j2
@@ -127,6 +127,7 @@ smtp-amavis        unix    -    -    n    -    2    smtp
 127.0.0.1:10027    inet    n    -    n    -    -    smtpd
    -o syslog_name=postfix/signer
    -o content_filter=
+   -o smtpd_tls_security_level=may
    -o local_recipient_maps=
    -o relay_recipient_maps=
    -o smtpd_restriction_classes=


### PR DESCRIPTION
based on: [Redhat docs](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/configuring-and-maintaining-a-dovecot-imap-and-pop3-server_deploying-different-types-of-servers#preparing-dovecot-to-use-virtual-users_setting-up-a-dovecot-server-with-pam-authentication)
